### PR TITLE
Clean employee and dashboard pages

### DIFF
--- a/src/pages/employees.tsx
+++ b/src/pages/employees.tsx
@@ -1,25 +1,6 @@
 import * as React from 'react';
-import { useParams } from 'react-router-dom'; // <= corregido
-import { Crud } from '@toolpad/core/Crud';
-import { employeesDataSource, Employee, employeesCache } from '../data/employees';
+import { PageContainer } from '@toolpad/core/PageContainer';
 
-const CrudEmployees = Crud<Employee>; // <= alias sin genérico en el JSX
-
-export default function EmployeesCrudPage() {
-  const { employeeId } = useParams();
-
-  return (
-    <CrudEmployees
-      dataSource={employeesDataSource}
-      dataSourceCache={employeesCache}
-      rootPath="/employees"
-      initialPageSize={25}
-      defaultValues={{ itemCount: 1 }}
-      pageTitles={{
-        show: `Employee ${employeeId}`,
-        create: 'New Employee',
-        edit: `Employee ${employeeId} - Edit`,
-      }}
-    />
-  );
+export default function EmployeesPage() {
+  return <PageContainer />;
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,15 +1,6 @@
 import * as React from 'react';
-import Typography from '@mui/material/Typography';
 import { PageContainer } from '@toolpad/core/PageContainer';
 
 export default function HomePage() {
-  
-
-  return (    
-    <PageContainer>
-      <Typography>
-        Welcome to Toolpad Core!
-      </Typography>
-    </PageContainer>
-  );
+  return <PageContainer />;
 }


### PR DESCRIPTION
## Summary
- Simplify dashboard page to an empty container
- Replace employee CRUD page with empty container

## Testing
- `pnpm run test` *(fails: Missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_68b7597f8774832db7234f10db1927ed