### PR TITLE
refactor: minimal todo input and tag system

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,32 +5,34 @@ import {
   Button,
   Checkbox,
   Chip,
-  FormControl,
-  InputLabel,
   List,
   ListItem,
-  MenuItem,
-  Select,
   Stack,
-  TextField,
   Typography,
+  Autocomplete,
+  InputBase,
 } from '@mui/material';
+import TextareaAutosize from '@mui/base/TextareaAutosize';
+import AddIcon from '@mui/icons-material/Add';
 
 type Todo = {
   id: number;
-  text: string;
-  priority: 'Alta' | 'Media' | 'Baja';
+  title: string;
+  description: string;
+  tags: string[];
   completed: boolean;
   createdAt: Date;
 };
 
 export default function ToDoGinNorPage() {
   const [todos, setTodos] = React.useState<Todo[]>([]);
-  const [text, setText] = React.useState('');
-  const [priority, setPriority] = React.useState<'Alta' | 'Media' | 'Baja'>('Media');
+  const [showForm, setShowForm] = React.useState(false);
+  const [title, setTitle] = React.useState('');
+  const [description, setDescription] = React.useState('');
+  const [tags, setTags] = React.useState<string[]>([]);
 
   const addTodo = () => {
-    if (!text.trim()) {
+    if (!title.trim()) {
       return;
     }
 
@@ -38,73 +40,129 @@ export default function ToDoGinNorPage() {
       ...todos,
       {
         id: Date.now(),
-        text: text.trim(),
-        priority,
+        title: title.trim(),
+        description: description.trim(),
+        tags,
         completed: false,
         createdAt: new Date(),
       },
     ]);
 
-    setText('');
-    setPriority('Media');
+    setTitle('');
+    setDescription('');
+    setTags([]);
+    setShowForm(false);
   };
 
   const toggleTodo = (id: number) => {
     setTodos(todos.map((todo) => (todo.id === id ? { ...todo, completed: !todo.completed } : todo)));
   };
 
+  const defaultTags = ['Alta', 'Media', 'Baja'];
+
   return (
     <PageContainer>
       <Stack spacing={2}>
-        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
-          <TextField
-            label="Nueva tarea"
-            value={text}
-            onChange={(e) => setText(e.target.value)}
-            fullWidth
-          />
-          <FormControl sx={{ minWidth: 120 }}>
-            <InputLabel id="priority-label">Prioridad</InputLabel>
-            <Select
-              labelId="priority-label"
-              value={priority}
-              label="Prioridad"
-              onChange={(e) => setPriority(e.target.value as 'Alta' | 'Media' | 'Baja')}
-            >
-              <MenuItem value="Alta">Alta</MenuItem>
-              <MenuItem value="Media">Media</MenuItem>
-              <MenuItem value="Baja">Baja</MenuItem>
-            </Select>
-          </FormControl>
-          <Button variant="contained" onClick={addTodo}>
-            Agregar
-          </Button>
-        </Stack>
+        {showForm ? (
+          <Box
+            sx={{
+              border: '1px solid',
+              borderColor: 'divider',
+              borderRadius: 1,
+              p: 2,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 1,
+            }}
+          >
+            <InputBase
+              placeholder="Título"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              sx={{ fontSize: 20 }}
+              fullWidth
+            />
+            <TextareaAutosize
+              placeholder="Descripción"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              style={{
+                width: '100%',
+                border: 'none',
+                outline: 'none',
+                fontFamily: 'inherit',
+                fontSize: '1rem',
+              }}
+            />
+            <Autocomplete
+              multiple
+              freeSolo
+              options={defaultTags}
+              value={tags}
+              onChange={(_, newValue) => setTags(newValue)}
+              renderTags={(value, getTagProps) =>
+                value.map((option, index) => (
+                  <Chip variant="outlined" label={option} {...getTagProps({ index })} />
+                ))
+              }
+              renderInput={(params) => (
+                <InputBase
+                  ref={params.InputProps.ref}
+                  {...params.inputProps}
+                  placeholder="Prioridades"
+                  sx={{ width: '100%' }}
+                />
+              )}
+            />
+            <Button variant="contained" onClick={addTodo} sx={{ alignSelf: 'flex-end', mt: 1 }}>
+              Agregar
+            </Button>
+          </Box>
+        ) : (
+          <Box
+            onClick={() => setShowForm(true)}
+            sx={{
+              border: '2px dashed',
+              borderColor: 'divider',
+              borderRadius: 1,
+              p: 4,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              cursor: 'pointer',
+            }}
+          >
+            <AddIcon />
+          </Box>
+        )}
         <List>
           {todos.map((todo) => (
-            <ListItem key={todo.id} sx={{ display: 'flex', alignItems: 'center' }}>
+            <ListItem key={todo.id} sx={{ display: 'flex', alignItems: 'flex-start' }}>
               <Checkbox checked={todo.completed} onChange={() => toggleTodo(todo.id)} />
               <Box sx={{ flexGrow: 1 }}>
                 <Typography
-                  variant="body1"
+                  variant="h6"
                   sx={{ textDecoration: todo.completed ? 'line-through' : 'none' }}
                 >
-                  {todo.text}
+                  {todo.title}
                 </Typography>
+                {todo.description && (
+                  <Typography
+                    variant="body2"
+                    sx={{ textDecoration: todo.completed ? 'line-through' : 'none' }}
+                  >
+                    {todo.description}
+                  </Typography>
+                )}
                 <Typography variant="caption" color="text.secondary">
                   {todo.createdAt.toLocaleString()}
                 </Typography>
               </Box>
-              <Chip
-                label={todo.priority}
-                color={
-                  todo.priority === 'Alta'
-                    ? 'error'
-                    : todo.priority === 'Media'
-                    ? 'warning'
-                    : 'default'
-                }
-              />
+              <Stack direction="row" spacing={1}>
+                {todo.tags.map((tag) => (
+                  <Chip key={tag} label={tag} variant="outlined" size="small" />
+                ))}
+              </Stack>
             </ListItem>
           ))}
         </List>


### PR DESCRIPTION
## Summary
- redesign todo entry with full-width dashed button
- inline form with borderless title, description and tag input
- allow priority tags with predefined options or custom labels

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b76398e730832d9bdde16d81c52aba