### PR TITLE
feat: style dark mode like GitHub

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { ReactRouterAppProvider } from '@toolpad/core/react-router';
 import type { Navigation, Authentication } from '@toolpad/core/AppProvider';
 import { firebaseSignOut, onAuthStateChanged } from './firebase/auth';
 import SessionContext, { type Session } from './SessionContext';
+import theme from '../theme';
 
 const NAVIGATION: Navigation = [
   {
@@ -64,6 +65,7 @@ export default function App() {
       branding={BRANDING}
       session={session}
       authentication={AUTHENTICATION}
+      theme={theme}
     >
       <SessionContext.Provider value={sessionContextValue}>
         <Outlet />

--- a/theme.ts
+++ b/theme.ts
@@ -1,13 +1,31 @@
 
-  "use client";
-  import { createTheme } from '@mui/material/styles';
+"use client";
+import { createTheme } from '@mui/material/styles';
 
-  const theme = createTheme({
-    cssVariables: {
-      colorSchemeSelector: 'data-toolpad-color-scheme',
+const theme = createTheme({
+  cssVariables: {
+    colorSchemeSelector: 'data-toolpad-color-scheme',
+  },
+  colorSchemes: {
+    light: {},
+    dark: {
+      palette: {
+        primary: {
+          main: '#1f6feb',
+        },
+        background: {
+          default: '#0d1117',
+          paper: '#161b22',
+        },
+        text: {
+          primary: '#c9d1d9',
+          secondary: '#8b949e',
+        },
+        divider: '#30363d',
+      },
     },
-    colorSchemes: { light: true, dark: true },
-  });
+  },
+});
 
-  export default theme;
+export default theme;
   


### PR DESCRIPTION
## Summary
- apply GitHub-inspired palette for dark mode
- hook theme into `ReactRouterAppProvider`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b7694686f0832db3cc3b0a24106831