### PR TITLE
feat: add calendar view with shared todo store

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,9 +4,14 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Toolpad Core App</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.css"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>
+    <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
 import ListAltIcon from '@mui/icons-material/ListAlt';
+import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
 import { Outlet } from 'react-router';
 import { ReactRouterAppProvider } from '@toolpad/core/react-router';
 import type { Navigation, Authentication } from '@toolpad/core/AppProvider';
 import { firebaseSignOut, onAuthStateChanged } from './firebase/auth';
 import SessionContext, { type Session } from './SessionContext';
+import { TodoProvider } from './TodoContext';
 import theme from '../theme';
 
 const NAVIGATION: Navigation = [
@@ -13,8 +15,14 @@ const NAVIGATION: Navigation = [
     title: 'Main items',
   },
   {
+    segment: '',
     title: 'To Do GinNor',
     icon: <ListAltIcon />,
+  },
+  {
+    segment: 'calendar',
+    title: 'Calendario',
+    icon: <CalendarMonthIcon />,
   },
 ];
 
@@ -68,7 +76,9 @@ export default function App() {
       theme={theme}
     >
       <SessionContext.Provider value={sessionContextValue}>
-        <Outlet />
+        <TodoProvider>
+          <Outlet />
+        </TodoProvider>
       </SessionContext.Provider>
     </ReactRouterAppProvider>
   );

--- a/src/TodoContext.tsx
+++ b/src/TodoContext.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+
+export type Todo = {
+  id: number;
+  title: string;
+  description: string;
+  tags: string[];
+  completed: boolean;
+  createdAt: Date;
+};
+
+interface TodoContextValue {
+  todos: Todo[];
+  addTodo: (todo: Omit<Todo, 'id'>) => void;
+  toggleTodo: (id: number) => void;
+}
+
+const TodoContext = React.createContext<TodoContextValue | undefined>(undefined);
+
+export function TodoProvider({ children }: { children: React.ReactNode }) {
+  const [todos, setTodos] = React.useState<Todo[]>([]);
+
+  const addTodo = (todo: Omit<Todo, 'id'>) => {
+    setTodos((prev) => [...prev, { ...todo, id: Date.now() }]);
+  };
+
+  const toggleTodo = (id: number) => {
+    setTodos((prev) => prev.map((t) => (t.id === id ? { ...t, completed: !t.completed } : t)));
+  };
+
+  return (
+    <TodoContext.Provider value={{ todos, addTodo, toggleTodo }}>
+      {children}
+    </TodoContext.Provider>
+  );
+}
+
+export function useTodoStore() {
+  const context = React.useContext(TodoContext);
+  if (!context) {
+    throw new Error('useTodoStore must be used within a TodoProvider');
+  }
+  return context;
+}
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import App from './App';
 import Layout from './layouts/main';
 import ToDoGinNorPage from './pages';
 import SignInPage from './pages/signin';
+import CalendarPage from './pages/calendar';
 
 const router = createBrowserRouter([
   {
@@ -17,6 +18,10 @@ const router = createBrowserRouter([
           {
             path: '',
             Component: ToDoGinNorPage,
+          },
+          {
+            path: 'calendar',
+            Component: CalendarPage,
           },
         ],
       },

--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { PageContainer } from '@toolpad/core/PageContainer';
+import { useTodoStore } from '../TodoContext';
+
+declare global {
+  interface Window {
+    FullCalendar: any;
+  }
+}
+
+export default function CalendarPage() {
+  const { todos } = useTodoStore();
+  const calendarRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    if (calendarRef.current && window.FullCalendar) {
+      const calendar = new window.FullCalendar.Calendar(calendarRef.current, {
+        initialView: 'dayGridMonth',
+        events: todos.map((todo) => ({
+          id: String(todo.id),
+          title: todo.title,
+          start: todo.createdAt,
+        })),
+      });
+      calendar.render();
+      return () => calendar.destroy();
+    }
+  }, [todos]);
+
+  return (
+    <PageContainer>
+      <div ref={calendarRef} />
+    </PageContainer>
+  );
+}
+

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -14,48 +14,32 @@ import {
   InputBase,
 } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
-
-type Todo = {
-  id: number;
-  title: string;
-  description: string;
-  tags: string[];
-  completed: boolean;
-  createdAt: Date;
-};
+import { useTodoStore } from '../TodoContext';
 
 export default function ToDoGinNorPage() {
-  const [todos, setTodos] = React.useState<Todo[]>([]);
+  const { todos, addTodo, toggleTodo } = useTodoStore();
   const [showForm, setShowForm] = React.useState(false);
   const [title, setTitle] = React.useState('');
   const [description, setDescription] = React.useState('');
   const [tags, setTags] = React.useState<string[]>([]);
 
-  const addTodo = () => {
+  const handleAdd = () => {
     if (!title.trim()) {
       return;
     }
 
-    setTodos([
-      ...todos,
-      {
-        id: Date.now(),
-        title: title.trim(),
-        description: description.trim(),
-        tags,
-        completed: false,
-        createdAt: new Date(),
-      },
-    ]);
+    addTodo({
+      title: title.trim(),
+      description: description.trim(),
+      tags,
+      completed: false,
+      createdAt: new Date(),
+    });
 
     setTitle('');
     setDescription('');
     setTags([]);
     setShowForm(false);
-  };
-
-  const toggleTodo = (id: number) => {
-    setTodos(todos.map((todo) => (todo.id === id ? { ...todo, completed: !todo.completed } : todo)));
   };
 
   const defaultTags = ['Alta', 'Media', 'Baja'];
@@ -113,7 +97,7 @@ export default function ToDoGinNorPage() {
                 />
               )}
             />
-            <Button variant="contained" onClick={addTodo} sx={{ alignSelf: 'flex-end', mt: 1 }}>
+            <Button variant="contained" onClick={handleAdd} sx={{ alignSelf: 'flex-end', mt: 1 }}>
               Agregar
             </Button>
           </Box>


### PR DESCRIPTION
## Summary
- add global todo store to share tasks
- integrate FullCalendar calendar page
- expose calendar in navigation

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b76df5689c832d85ce80da1595256c