### PR TITLE
feat: edit and delete ToDo events

### DIFF
--- a/src/TodoContext.tsx
+++ b/src/TodoContext.tsx
@@ -13,6 +13,8 @@ interface TodoContextValue {
   todos: Todo[];
   addTodo: (todo: Omit<Todo, 'id'>) => void;
   toggleTodo: (id: number) => void;
+  updateTodo: (id: number, updates: Partial<Omit<Todo, 'id'>>) => void;
+  removeTodo: (id: number) => void;
 }
 
 const TodoContext = React.createContext<TodoContextValue | undefined>(undefined);
@@ -28,8 +30,18 @@ export function TodoProvider({ children }: { children: React.ReactNode }) {
     setTodos((prev) => prev.map((t) => (t.id === id ? { ...t, completed: !t.completed } : t)));
   };
 
+  const updateTodo = (id: number, updates: Partial<Omit<Todo, 'id'>>) => {
+    setTodos((prev) => prev.map((t) => (t.id === id ? { ...t, ...updates } : t)));
+  };
+
+  const removeTodo = (id: number) => {
+    setTodos((prev) => prev.filter((t) => t.id !== id));
+  };
+
   return (
-    <TodoContext.Provider value={{ todos, addTodo, toggleTodo }}>
+    <TodoContext.Provider
+      value={{ todos, addTodo, toggleTodo, updateTodo, removeTodo }}
+    >
       {children}
     </TodoContext.Provider>
   );

--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -9,18 +9,40 @@ declare global {
 }
 
 export default function CalendarPage() {
-  const { todos } = useTodoStore();
+  const { todos, updateTodo, removeTodo } = useTodoStore();
   const calendarRef = React.useRef<HTMLDivElement>(null);
 
   React.useEffect(() => {
     if (calendarRef.current && window.FullCalendar) {
       const calendar = new window.FullCalendar.Calendar(calendarRef.current, {
         initialView: 'dayGridMonth',
+        editable: true,
         events: todos.map((todo) => ({
           id: String(todo.id),
           title: todo.title,
           start: todo.createdAt,
         })),
+        eventClick: (info: any) => {
+          const newTitle = window.prompt(
+            'Nuevo título (deje vacío para eliminar)',
+            info.event.title,
+          );
+          if (newTitle === null) {
+            return;
+          }
+          if (!newTitle.trim()) {
+            if (window.confirm('¿Eliminar este evento?')) {
+              removeTodo(Number(info.event.id));
+            }
+          } else {
+            updateTodo(Number(info.event.id), { title: newTitle.trim() });
+          }
+        },
+        eventDrop: (info: any) => {
+          if (info.event.start) {
+            updateTodo(Number(info.event.id), { createdAt: info.event.start });
+          }
+        },
       });
       calendar.render();
       return () => calendar.destroy();

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,6 +5,7 @@ import {
   Button,
   Checkbox,
   Chip,
+  IconButton,
   List,
   ListItem,
   Stack,
@@ -14,14 +15,23 @@ import {
   InputBase,
 } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import SaveIcon from '@mui/icons-material/Save';
+import CloseIcon from '@mui/icons-material/Close';
 import { useTodoStore } from '../TodoContext';
 
 export default function ToDoGinNorPage() {
-  const { todos, addTodo, toggleTodo } = useTodoStore();
+  const { todos, addTodo, toggleTodo, updateTodo, removeTodo } = useTodoStore();
   const [showForm, setShowForm] = React.useState(false);
   const [title, setTitle] = React.useState('');
   const [description, setDescription] = React.useState('');
   const [tags, setTags] = React.useState<string[]>([]);
+  const [editingId, setEditingId] = React.useState<number | null>(null);
+  const [editTitle, setEditTitle] = React.useState('');
+  const [editDescription, setEditDescription] = React.useState('');
+  const [editTags, setEditTags] = React.useState<string[]>([]);
+  const [editDate, setEditDate] = React.useState('');
 
   const handleAdd = () => {
     if (!title.trim()) {
@@ -40,6 +50,37 @@ export default function ToDoGinNorPage() {
     setDescription('');
     setTags([]);
     setShowForm(false);
+  };
+
+  const startEdit = (todo: typeof todos[number]) => {
+    setEditingId(todo.id);
+    setEditTitle(todo.title);
+    setEditDescription(todo.description);
+    setEditTags(todo.tags);
+    setEditDate(todo.createdAt.toISOString().slice(0, 16));
+  };
+
+  const handleSave = () => {
+    if (editingId === null) return;
+    updateTodo(editingId, {
+      title: editTitle.trim(),
+      description: editDescription.trim(),
+      tags: editTags,
+      createdAt: editDate ? new Date(editDate) : new Date(),
+    });
+    setEditingId(null);
+    setEditTitle('');
+    setEditDescription('');
+    setEditTags([]);
+    setEditDate('');
+  };
+
+  const cancelEdit = () => {
+    setEditingId(null);
+    setEditTitle('');
+    setEditDescription('');
+    setEditTags([]);
+    setEditDate('');
   };
 
   const defaultTags = ['Alta', 'Media', 'Baja'];
@@ -123,29 +164,101 @@ export default function ToDoGinNorPage() {
             <ListItem key={todo.id} sx={{ display: 'flex', alignItems: 'flex-start' }}>
               <Checkbox checked={todo.completed} onChange={() => toggleTodo(todo.id)} />
               <Box sx={{ flexGrow: 1 }}>
-                <Typography
-                  variant="h6"
-                  sx={{ textDecoration: todo.completed ? 'line-through' : 'none' }}
-                >
-                  {todo.title}
-                </Typography>
-                {todo.description && (
-                  <Typography
-                    variant="body2"
-                    sx={{ textDecoration: todo.completed ? 'line-through' : 'none' }}
-                  >
-                    {todo.description}
-                  </Typography>
+                {editingId === todo.id ? (
+                  <React.Fragment>
+                    <InputBase
+                      value={editTitle}
+                      onChange={(e) => setEditTitle(e.target.value)}
+                      sx={{ fontSize: 20 }}
+                      fullWidth
+                    />
+                    <TextareaAutosize
+                      value={editDescription}
+                      onChange={(e) => setEditDescription(e.target.value)}
+                      style={{
+                        width: '100%',
+                        border: 'none',
+                        outline: 'none',
+                        fontFamily: 'inherit',
+                        fontSize: '1rem',
+                      }}
+                    />
+                    <Autocomplete
+                      multiple
+                      freeSolo
+                      options={defaultTags}
+                      value={editTags}
+                      onChange={(_, newValue) => setEditTags(newValue)}
+                      renderTags={(value, getTagProps) =>
+                        value.map((option, index) => (
+                          <Chip
+                            variant="outlined"
+                            label={option}
+                            {...getTagProps({ index })}
+                          />
+                        ))
+                      }
+                      renderInput={(params) => (
+                        <InputBase
+                          {...params.inputProps}
+                          placeholder="Prioridades"
+                          sx={{ width: '100%' }}
+                        />
+                      )}
+                    />
+                    <InputBase
+                      type="datetime-local"
+                      value={editDate}
+                      onChange={(e) => setEditDate(e.target.value)}
+                      sx={{ mt: 1 }}
+                    />
+                  </React.Fragment>
+                ) : (
+                  <React.Fragment>
+                    <Typography
+                      variant="h6"
+                      sx={{ textDecoration: todo.completed ? 'line-through' : 'none' }}
+                    >
+                      {todo.title}
+                    </Typography>
+                    {todo.description && (
+                      <Typography
+                        variant="body2"
+                        sx={{ textDecoration: todo.completed ? 'line-through' : 'none' }}
+                      >
+                        {todo.description}
+                      </Typography>
+                    )}
+                    <Typography variant="caption" color="text.secondary">
+                      {todo.createdAt.toLocaleString()}
+                    </Typography>
+                    <Stack direction="row" spacing={1} sx={{ mt: 1 }}>
+                      {todo.tags.map((tag) => (
+                        <Chip key={tag} label={tag} variant="outlined" size="small" />
+                      ))}
+                    </Stack>
+                  </React.Fragment>
                 )}
-                <Typography variant="caption" color="text.secondary">
-                  {todo.createdAt.toLocaleString()}
-                </Typography>
               </Box>
-              <Stack direction="row" spacing={1}>
-                {todo.tags.map((tag) => (
-                  <Chip key={tag} label={tag} variant="outlined" size="small" />
-                ))}
-              </Stack>
+              {editingId === todo.id ? (
+                <Stack direction="row" spacing={1} sx={{ ml: 1 }}>
+                  <IconButton onClick={handleSave} color="primary">
+                    <SaveIcon />
+                  </IconButton>
+                  <IconButton onClick={cancelEdit} color="inherit">
+                    <CloseIcon />
+                  </IconButton>
+                </Stack>
+              ) : (
+                <Stack direction="row" spacing={1} sx={{ ml: 1 }}>
+                  <IconButton onClick={() => startEdit(todo)} color="inherit">
+                    <EditIcon />
+                  </IconButton>
+                  <IconButton onClick={() => removeTodo(todo.id)} color="inherit">
+                    <DeleteIcon />
+                  </IconButton>
+                </Stack>
+              )}
             </ListItem>
           ))}
         </List>


### PR DESCRIPTION
## Summary
- allow editing and removing todo items
- enable calendar event editing with FullCalendar

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc --noEmit src/TodoContext.tsx src/pages/index.tsx src/pages/calendar.tsx` *(fails: Cannot use JSX unless the '--jsx' flag is provided)*

------
https://chatgpt.com/codex/tasks/task_e_68b7710ff120832dbcd22bdfcfdfff98