### PR TITLE
feat: allow switching calendar views

### DIFF
--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -17,6 +17,17 @@ export default function CalendarPage() {
       const calendar = new window.FullCalendar.Calendar(calendarRef.current, {
         initialView: 'dayGridMonth',
         editable: true,
+        headerToolbar: {
+          start: 'dayGridMonth,timeGridWeek,timeGridDay',
+          center: 'title',
+          end: 'prev,next today',
+        },
+        buttonText: {
+          today: 'Hoy',
+          month: 'Mes',
+          week: 'Semana',
+          day: 'Día',
+        },
         events: todos.map((todo) => ({
           id: String(todo.id),
           title: todo.title,


### PR DESCRIPTION
## Summary
- add header toolbar to FullCalendar to switch between month, week and day views
- localize view buttons to Spanish

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx tsc --noEmit src/pages/calendar.tsx` *(fails: Module '../TodoContext' was resolved to 'src/TodoContext.tsx', but '--jsx' is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68ba494e5f60832da825975f12e7159e