### PR TITLE
feat: replace material calendar with fullcalendar

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,14 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Toolpad Core App</title>
-    <link
-      href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.css"
-      rel="stylesheet"
-    />
   </head>
   <body>
     <div id="root"></div>
-    <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -1,39 +1,43 @@
 import * as React from 'react';
 import { PageContainer } from '@toolpad/core/PageContainer';
+import FullCalendar from '@fullcalendar/react';
+import dayGridPlugin from '@fullcalendar/daygrid';
+import timeGridPlugin from '@fullcalendar/timegrid';
+import interactionPlugin from '@fullcalendar/interaction';
+import listPlugin from '@fullcalendar/list';
+import type { EventClickArg, EventDropArg } from '@fullcalendar/core';
+import '@fullcalendar/core/index.css';
+import '@fullcalendar/daygrid/index.css';
+import '@fullcalendar/timegrid/index.css';
+import '@fullcalendar/list/index.css';
 import { useTodoStore } from '../TodoContext';
-
-declare global {
-  interface Window {
-    FullCalendar: any;
-  }
-}
 
 export default function CalendarPage() {
   const { todos, updateTodo, removeTodo } = useTodoStore();
-  const calendarRef = React.useRef<HTMLDivElement>(null);
 
-  React.useEffect(() => {
-    if (calendarRef.current && window.FullCalendar) {
-      const calendar = new window.FullCalendar.Calendar(calendarRef.current, {
-        initialView: 'dayGridMonth',
-        editable: true,
-        headerToolbar: {
+  return (
+    <PageContainer>
+      <FullCalendar
+        plugins={[dayGridPlugin, timeGridPlugin, interactionPlugin, listPlugin]}
+        initialView="dayGridMonth"
+        editable
+        headerToolbar={{
           start: 'dayGridMonth,timeGridWeek,timeGridDay',
           center: 'title',
           end: 'prev,next today',
-        },
-        buttonText: {
+        }}
+        buttonText={{
           today: 'Hoy',
           month: 'Mes',
           week: 'Semana',
           day: 'Día',
-        },
-        events: todos.map((todo) => ({
+        }}
+        events={todos.map((todo) => ({
           id: String(todo.id),
           title: todo.title,
           start: todo.createdAt,
-        })),
-        eventClick: (info: any) => {
+        }))}
+        eventClick={(info: EventClickArg) => {
           const newTitle = window.prompt(
             'Nuevo título (deje vacío para eliminar)',
             info.event.title,
@@ -48,21 +52,13 @@ export default function CalendarPage() {
           } else {
             updateTodo(Number(info.event.id), { title: newTitle.trim() });
           }
-        },
-        eventDrop: (info: any) => {
+        }}
+        eventDrop={(info: EventDropArg) => {
           if (info.event.start) {
             updateTodo(Number(info.event.id), { createdAt: info.event.start });
           }
-        },
-      });
-      calendar.render();
-      return () => calendar.destroy();
-    }
-  }, [todos]);
-
-  return (
-    <PageContainer>
-      <div ref={calendarRef} />
+        }}
+      />
     </PageContainer>
   );
 }


### PR DESCRIPTION
## Summary
- render calendar with FullCalendar React component
- drop external CDN dependency

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ba527017f0832db3ad5905b53c6a44