### PR TITLE
feat: localize authentication to Spanish

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import type { Navigation, Authentication } from '@toolpad/core/AppProvider';
 import { firebaseSignOut, onAuthStateChanged } from './firebase/auth';
 import SessionContext, { type Session } from './SessionContext';
 import theme from '../theme';
+import { esLocaleText } from './locales/es';
 
 const NAVIGATION: Navigation = [
   {
@@ -73,6 +74,7 @@ export default function App() {
       session={session}
       authentication={AUTHENTICATION}
       theme={theme}
+      localeText={esLocaleText}
     >
       <SessionContext.Provider value={sessionContextValue}>
         <Outlet />

--- a/src/firebase/auth.ts
+++ b/src/firebase/auth.ts
@@ -29,7 +29,7 @@ export const signInWithGoogle = async () => {
     return {
       success: false,
       user: null,
-      error: error.message,
+      error: error.message || 'No se pudo iniciar sesión con Google',
     };
   }
 };
@@ -49,7 +49,7 @@ export const signInWithGithub = async () => {
     return {
       success: false,
       user: null,
-      error: error.message,
+      error: error.message || 'No se pudo iniciar sesión con GitHub',
     };
   }
 };
@@ -69,7 +69,7 @@ export const signInWithFacebook = async () => {
     return {
       success: false,
       user: null,
-      error: error.message,
+      error: error.message || 'No se pudo iniciar sesión con Facebook',
     };
   }
 };
@@ -102,7 +102,7 @@ export const firebaseSignOut = async () => {
   } catch (error: any) {
     return {
       success: false,
-      error: error.message,
+      error: error.message || 'No se pudo cerrar sesión',
     };
   }
 };

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -1,0 +1,18 @@
+import type { LocaleText } from '@toolpad/core/AppProvider/LocalizationProvider';
+
+export const esLocaleText: Partial<LocaleText> = {
+  accountSignInLabel: 'Iniciar sesión',
+  accountSignOutLabel: 'Cerrar sesión',
+  accountPreviewIconButtonLabel: 'Cuenta',
+  accountPreviewTitle: 'Perfil',
+  signInTitle: 'Inicia sesión en tu cuenta',
+  signInSubtitle: 'Selecciona un método de inicio de sesión',
+  signInRememberMe: 'Recordarme',
+  providerSignInTitle: (provider: string) => `Iniciar sesión con ${provider}`,
+  email: 'Correo electrónico',
+  password: 'Contraseña',
+  or: 'o',
+  with: 'con',
+  passkey: 'Clave de acceso',
+  to: 'a',
+};

--- a/src/pages/signin.tsx
+++ b/src/pages/signin.tsx
@@ -1,11 +1,11 @@
 'use client';
 import * as React from 'react';
-import Alert from '@mui/material/Alert';
 import LinearProgress from '@mui/material/LinearProgress';
 import { SignInPage } from '@toolpad/core/SignInPage';
 import { Navigate, useNavigate } from 'react-router';
 import { useSession, type Session } from '../SessionContext';
 import { signInWithGoogle, signInWithGithub, signInWithFacebook, signInWithCredentials } from '../firebase/auth';
+import { esLocaleText } from '../locales/es';
 
 
 export default function SignIn() {
@@ -22,7 +22,13 @@ export default function SignIn() {
 
   return (
     <SignInPage
-      providers={[{ id: 'google', name: 'Google' }, { id: 'github', name: 'GitHub' }, { id: 'facebook', name: 'Facebook' }, { id: 'credentials', name: 'Credentials' }]}
+      providers={[
+        { id: 'google', name: 'Google' },
+        { id: 'github', name: 'GitHub' },
+        { id: 'facebook', name: 'Facebook' },
+        { id: 'credentials', name: 'Correo electrónico y contraseña' },
+      ]}
+      localeText={esLocaleText}
       signIn={async (provider, formData, callbackUrl) => {
         let result;
         try {
@@ -40,7 +46,7 @@ export default function SignIn() {
             const password = formData?.get('password') as string;
 
             if (!email || !password) {
-              return { error: 'Email and password are required' };
+              return { error: 'El correo y la contraseña son obligatorios' };
             }
 
             result = await signInWithCredentials(email, password);
@@ -58,9 +64,11 @@ export default function SignIn() {
             navigate(callbackUrl || '/', { replace: true });
             return {};
           }
-          return { error: result?.error || 'Failed to sign in' };
+          return { error: result?.error || 'No se pudo iniciar sesión' };
         } catch (error) {
-          return { error: error instanceof Error ? error.message : 'An error occurred' };
+          return {
+            error: error instanceof Error ? error.message : 'Ocurrió un error',
+          };
         }
       }}
         


### PR DESCRIPTION
## Summary
- add Spanish locale text for authentication
- translate sign-in UI and errors to Spanish
- provide Spanish fallbacks in Firebase auth helpers

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bcad40af94832dadfed6af564a6bc4