### PR TITLE
Add Spanish JsDoc documentation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,9 @@ import SessionContext, { type Session } from './SessionContext';
 import theme from '../theme';
 import { esLocaleText } from './locales/es';
 
+/**
+ * Configuración de la navegación principal del panel, con los segmentos disponibles y sus iconos.
+ */
 const NAVIGATION: Navigation = [
   {
     kind: 'header',
@@ -26,19 +29,32 @@ const NAVIGATION: Navigation = [
   },
 ];
 
+/**
+ * Información de marca mostrada en la interfaz de Toolpad.
+ */
 const BRANDING = {
   title: 'To Do GinNor',
 };
 
-const AUTHENTICATION: Authentication = {    
+/**
+ * Implementación personalizada de los controladores de autenticación para el panel.
+ */
+const AUTHENTICATION: Authentication = {
   signIn: () => {},
   signOut: firebaseSignOut,
 };
 
+/**
+ * Componente raíz de la aplicación que configura el proveedor de Toolpad y el contexto de sesión.
+ * @returns {JSX.Element} Proveedor de Toolpad con las rutas hijas.
+ */
 export default function App() {
   const [session, setSession] = React.useState<Session | null>(null);
   const [loading, setLoading] = React.useState(true);
 
+  /**
+   * Memoriza el valor compartido del contexto de sesión para evitar renders innecesarios.
+   */
   const sessionContextValue = React.useMemo(
     () => ({
       session,
@@ -49,6 +65,9 @@ export default function App() {
   );
 
   React.useEffect(() => {
+    /**
+     * Suscribe al observador de autenticación de Firebase para mantener la sesión actualizada.
+     */
     const unsubscribe = onAuthStateChanged((user) => {
       if (user) {
         setSession({

--- a/src/SessionContext.ts
+++ b/src/SessionContext.ts
@@ -1,5 +1,8 @@
 import * as React from 'react';
 
+/**
+ * Representa la información de sesión asociada a un usuario autenticado.
+ */
 export interface Session {
   user: {
     name?: string;
@@ -8,12 +11,18 @@ export interface Session {
   };
 }
 
+/**
+ * Define la forma del contexto de sesión compartido en la aplicación.
+ */
 interface SessionContextType {
   session: Session | null;
   setSession: (session: Session | null) => void;
   loading: boolean;
 }
 
+/**
+ * Contexto de React que expone la sesión actual y utilidades relacionadas.
+ */
 const SessionContext = React.createContext<SessionContextType>({
   session: null,
   setSession: () => {},
@@ -22,4 +31,8 @@ const SessionContext = React.createContext<SessionContextType>({
 
 export default SessionContext;
 
+/**
+ * Hook de conveniencia para consumir el contexto de sesión en componentes funcionales.
+ * @returns {SessionContextType} Estado actual de la sesión y utilidades asociadas.
+ */
 export const useSession = () => React.useContext(SessionContext);

--- a/src/firebase/auth.ts
+++ b/src/firebase/auth.ts
@@ -10,11 +10,17 @@ import {
 } from 'firebase/auth';
 import { firebaseAuth } from './firebaseConfig';
 
+/** Proveedor de autenticación de Google utilizado por Firebase. */
 const googleProvider = new GoogleAuthProvider();
+/** Proveedor de autenticación de GitHub utilizado por Firebase. */
 const githubProvider = new GithubAuthProvider();
+/** Proveedor de autenticación de Facebook utilizado por Firebase. */
 const facebookProvider = new FacebookAuthProvider();
 
-// Sign in with Google functionality
+/**
+ * Inicia sesión con el proveedor de Google y mantiene la sesión en el almacenamiento de sesión del navegador.
+ * @returns {Promise<{ success: boolean; user: any; error: string | null }>} Resultado de la autenticación.
+ */
 export const signInWithGoogle = async () => {
   try {
     return setPersistence(firebaseAuth, browserSessionPersistence).then(async () => {
@@ -34,7 +40,10 @@ export const signInWithGoogle = async () => {
   }
 };
 
-// Sign in with GitHub functionality
+/**
+ * Inicia sesión con el proveedor de GitHub y aplica persistencia de sesión del navegador.
+ * @returns {Promise<{ success: boolean; user: any; error: string | null }>} Resultado de la autenticación.
+ */
 export const signInWithGithub = async () => {
   try {
     return setPersistence(firebaseAuth, browserSessionPersistence).then(async () => {
@@ -54,7 +63,10 @@ export const signInWithGithub = async () => {
   }
 };
 
-// sign in with Facebook functionality
+/**
+ * Inicia sesión con el proveedor de Facebook y conserva la sesión en el navegador.
+ * @returns {Promise<{ success: boolean; user: any; error: string | null }>} Resultado de la autenticación.
+ */
 export const signInWithFacebook = async () => {
   try {
     return setPersistence(firebaseAuth, browserSessionPersistence).then(async () => {
@@ -74,7 +86,12 @@ export const signInWithFacebook = async () => {
   }
 };
 
-// Sign in with email and password
+/**
+ * Inicia sesión con correo electrónico y contraseña utilizando el servicio de autenticación de Firebase.
+ * @param {string} email Correo electrónico del usuario.
+ * @param {string} password Contraseña del usuario.
+ * @returns {Promise<{ success: boolean; user: any; error: string | null }>} Resultado de la autenticación.
+ */
 export async function signInWithCredentials(email: string, password: string) {
   try {
     return setPersistence(firebaseAuth, browserSessionPersistence).then(async () => {
@@ -94,7 +111,10 @@ export async function signInWithCredentials(email: string, password: string) {
   }
 }
 
-// Sign out functionality
+/**
+ * Cierra la sesión del usuario autenticado en Firebase.
+ * @returns {Promise<{ success: boolean; error?: string }>} Estado del cierre de sesión.
+ */
 export const firebaseSignOut = async () => {
   try {
     await signOut(firebaseAuth);
@@ -107,7 +127,11 @@ export const firebaseSignOut = async () => {
   }
 };
 
-// Auth state observer
+/**
+ * Observa los cambios en el estado de autenticación de Firebase y ejecuta un callback.
+ * @param {(user: any) => void} callback Función que se invoca cuando cambia el usuario autenticado.
+ * @returns {import('firebase/auth').Unsubscribe} Función para cancelar la suscripción.
+ */
 export const onAuthStateChanged = (callback: (user: any) => void) => {
   return firebaseAuth.onAuthStateChanged(callback);
 };

--- a/src/firebase/firebaseConfig.ts
+++ b/src/firebase/firebaseConfig.ts
@@ -1,6 +1,9 @@
 import { initializeApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
 
+/**
+ * Variables de entorno obligatorias necesarias para inicializar Firebase.
+ */
 const requiredEnvVars = {
   VITE_FIREBASE_API_KEY: import.meta.env.VITE_FIREBASE_API_KEY,
   VITE_FIREBASE_AUTH_DOMAIN: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
@@ -10,13 +13,18 @@ const requiredEnvVars = {
   VITE_FIREBASE_APP_ID: import.meta.env.VITE_FIREBASE_APP_ID,
 };
 
-// Check for missing environment variables
+/**
+ * Verifica que todas las variables de entorno requeridas estén presentes y emite advertencias en caso contrario.
+ */
 Object.entries(requiredEnvVars).forEach(([key, value]) => {
   if (!value) {
     console.warn(`Missing required environment variable: ${key}`);
   }
 });
 
+/**
+ * Instancia de la aplicación de Firebase configurada con los valores de entorno.
+ */
 const app = initializeApp({
   apiKey: requiredEnvVars.VITE_FIREBASE_API_KEY,
   authDomain: requiredEnvVars.VITE_FIREBASE_AUTH_DOMAIN,
@@ -26,5 +34,8 @@ const app = initializeApp({
   appId: requiredEnvVars.VITE_FIREBASE_APP_ID,
 });
 
+/**
+ * Instancia del servicio de autenticación de Firebase utilizada en toda la aplicación.
+ */
 export const firebaseAuth = getAuth(app);
 export default app;

--- a/src/layouts/main.tsx
+++ b/src/layouts/main.tsx
@@ -7,6 +7,10 @@ import { Account } from '@toolpad/core/Account';
 
 import { useSession } from '../SessionContext';
 
+/**
+ * Renderiza las acciones personalizadas que aparecen en la barra de herramientas del panel.
+ * @returns {JSX.Element} Contenedor con el selector de tema y la cuenta del usuario.
+ */
 function CustomActions() {
   return (
     <Stack direction="row" alignItems="center">
@@ -20,6 +24,10 @@ function CustomActions() {
   );
 }
 
+/**
+ * Layout principal que protege las rutas autenticadas y muestra un cargador mientras se obtiene la sesión.
+ * @returns {JSX.Element} Disposición del panel o una redirección a la página de inicio de sesión.
+ */
 export default function Layout() {
   const { session, loading } = useSession();
   const location = useLocation();
@@ -38,7 +46,7 @@ export default function Layout() {
   }
 
   return (
-    <DashboardLayout  slots={{ toolbarActions: CustomActions }}>
+    <DashboardLayout slots={{ toolbarActions: CustomActions }}>
       <Outlet />
     </DashboardLayout>
   );

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -1,5 +1,8 @@
 import type { LocaleText } from '@toolpad/core';
 
+/**
+ * Traducciones al español utilizadas por los componentes de autenticación de Toolpad.
+ */
 export const esLocaleText: Partial<LocaleText> = {
   accountSignInLabel: 'Iniciar sesión',
   accountSignOutLabel: 'Cerrar sesión',

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,9 @@ import TodoPage from './pages';
 import SignInPage from './pages/signin';
 import CalendarPage from './pages/calendar';
 
+/**
+ * Definición de las rutas de la aplicación y su jerarquía.
+ */
 const router = createBrowserRouter([
   {
     Component: App,
@@ -33,6 +36,9 @@ const router = createBrowserRouter([
   },
 ]);
 
+/**
+ * Punto de entrada que monta la aplicación de React en el DOM.
+ */
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <RouterProvider router={router} />

--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -1,5 +1,10 @@
 import { PageContainer } from '@toolpad/core/PageContainer';
 
+/**
+ * Página que mostrará el calendario de eventos.
+ * @returns {JSX.Element} Contenedor de página para el calendario.
+ */
 export default function CalendarPage() {
   return <PageContainer />;
 }
+

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,10 @@
 import { PageContainer } from '@toolpad/core/PageContainer';
 
+/**
+ * Página principal de tareas del panel.
+ * @returns {JSX.Element} Contenedor de página vacío listo para personalización.
+ */
 export default function TodoPage() {
   return <PageContainer />;
 }
+

--- a/src/pages/signin.tsx
+++ b/src/pages/signin.tsx
@@ -7,6 +7,10 @@ import { signInWithGoogle, signInWithGithub, signInWithFacebook, signInWithCrede
 import { esLocaleText } from '../locales/es';
 
 
+/**
+ * Página de inicio de sesión que ofrece múltiples proveedores y credenciales manuales.
+ * @returns {JSX.Element} Interfaz de autenticación para el usuario.
+ */
 export default function SignIn() {
   const { session, setSession, loading } = useSession();
   const navigate = useNavigate();
@@ -29,6 +33,9 @@ export default function SignIn() {
       ]}
       localeText={esLocaleText}
       signIn={async (provider, formData, callbackUrl) => {
+        /**
+         * Gestiona el flujo de autenticación según el proveedor seleccionado por el usuario.
+         */
         let result;
         try {
           if (provider.id === 'google') {

--- a/theme.ts
+++ b/theme.ts
@@ -2,6 +2,9 @@
 "use client";
 import { createTheme } from '@mui/material/styles';
 
+/**
+ * Tema personalizado de MUI con variables para alternar esquemas de color.
+ */
 const theme = createTheme({
   cssVariables: {
     colorSchemeSelector: 'data-toolpad-color-scheme',
@@ -28,4 +31,3 @@ const theme = createTheme({
 });
 
 export default theme;
-  


### PR DESCRIPTION
## Summary
- documentar la configuración principal de la aplicación con comentarios JsDoc en español
- añadir descripciones en español a los módulos de autenticación y contexto de sesión
- completar la documentación de páginas, locales y tema compartido

## Testing
- no se requirieron pruebas


------
https://chatgpt.com/codex/tasks/task_e_68dfd1aeb6c4832da42c8a23579852b5